### PR TITLE
Add additional options for anchor positioning & display

### DIFF
--- a/components/ui/anchor.tsx
+++ b/components/ui/anchor.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { cn } from '@/lib/utils';
+import { LinkIcon } from 'lucide-react';
+import Link from 'next/link';
+
+export default function Anchor({
+  anchor,
+  alwaysDisplay,
+}: {
+  anchor: string;
+  alwaysDisplay: boolean;
+}) {
+  function copyToClipboard() {
+    const currentUrl = window.location.href.replace(/#.*$/, '');
+    const urlWithId = `${currentUrl}#${anchor}`;
+
+    navigator.clipboard.writeText(urlWithId);
+  }
+
+  return (
+    <div className={cn('ms-2 pt-1', !alwaysDisplay && 'invisible group-hover:visible')}>
+      {/* modify `Link` to `a` if you are not using Next.js */}
+      <Link href={`#${anchor}`} onClick={copyToClipboard}>
+        <LinkIcon className="text-gray-600 hover:text-gray-400" />
+      </Link>
+    </div>
+  );
+}

--- a/components/ui/heading-with-anchor.tsx
+++ b/components/ui/heading-with-anchor.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { cn } from '@/lib/utils';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { LinkIcon } from 'lucide-react';
-import Link from 'next/link';
+import React from 'react';
+import Anchor from './anchor';
 const headingVariants = cva('font-bold text-primary', {
   variants: {
     variant: {
@@ -27,8 +26,14 @@ type BaseHeadingProps = {
   className?: string;
   asChild?: boolean;
   anchor?: string;
+  args?: HeadingArgs;
 } & React.HTMLAttributes<HTMLHeadingElement> &
   VariantProps<typeof headingVariants>;
+
+type HeadingArgs = {
+  alignAnchor?: 'close' | 'spaced';
+  alwaysDisplay?: boolean;
+};
 
 const BaseHeading = ({
   children,
@@ -36,30 +41,25 @@ const BaseHeading = ({
   variant = 'h6',
   asChild = false,
   anchor,
+  args: { alignAnchor = 'close', alwaysDisplay = false } = {},
   ...props
 }: BaseHeadingProps) => {
   const Comp = asChild ? Slot : variant;
   return (
-    <>
+    <div className="group">
       <Comp
         id={anchor}
         {...props}
         className={cn(
-          anchor && 'flex scroll-m-20 items-center justify-between', // modify `scroll-m-20` according to your header height.
+          anchor && 'flex scroll-m-20 items-center', // modify `scroll-m-20` according to your header height.
           headingVariants({ variant, className }),
+          alignAnchor === 'spaced' && 'justify-between',
         )}
       >
         {children}
-        {anchor && (
-          <>
-            {/* modify `Link` to `a` if you are not using Next.js */}
-            <Link href={`#${anchor}`}>
-              <LinkIcon className="text-gray-400 hover:text-gray-600" />
-            </Link>
-          </>
-        )}
+        {anchor && <Anchor anchor={anchor} alwaysDisplay={alwaysDisplay} />}
       </Comp>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Changes
- I added the options to set if the anchor icon should **always** be display or just on **hover** over the Heading div.
- Added the option to switch the location of the anchor icon between `spaced` or `close`.

## ToDos?

- [ ] Add new variants to overview page?