### PR TITLE
chore: Add missing dependencies to effects used in the MultipleSelector component

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -200,7 +200,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
         setSelected(newOptions);
         onChange?.(newOptions);
       },
-      [selected],
+      [onChange, selected],
     );
 
     const handleKeyDown = React.useCallback(
@@ -218,7 +218,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
           }
         }
       },
-      [selected],
+      [handleUnselect, selected],
     );
 
     useEffect(() => {
@@ -259,7 +259,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       };
 
       void exec();
-    }, [debouncedSearchTerm, open]);
+    }, [debouncedSearchTerm, groupBy, onSearch, open, triggerSearchOnFocus]);
 
     const CreatableItem = () => {
       if (!creatable) return undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shadcn-ui-expensions",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shadcn-ui-expensions",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -43,6 +43,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.1.3",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "next-sitemap": "^4.2.3",
         "postcss": "^8",
         "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.1.3",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "next-sitemap": "^4.2.3",
     "postcss": "^8",
     "prettier": "^3.2.5",


### PR DESCRIPTION
The `<MultipleSelector>` component has a few effects that have missing dependencies. We can observe this by installing the `eslint-plugin-react-hooks` eslint plugin.

This commit adds the plugin to the project (to help catch and future dependency issues) and fixes the warnings in the component. By adding the missing dependencies to the effects, we make sure the effects are triggered again in the case of said props changing.

I've made these changes to my actively used version of this component and haven't observed any side-effects.

- https://react.dev/reference/rules/rules-of-hooks
- https://www.npmjs.com/package/eslint-plugin-react-hooks