### PR TITLE
Fixes autosize-textarea.tsx focus error

### DIFF
--- a/components/ui/autosize-textarea.tsx
+++ b/components/ui/autosize-textarea.tsx
@@ -76,6 +76,7 @@ export const AutosizeTextarea = React.forwardRef<AutosizeTextAreaRef, AutosizeTe
 
     useImperativeHandle(ref, () => ({
       textArea: textAreaRef.current as HTMLTextAreaElement,
+      focus: () => textAreaRef.current?.focus(),
       maxHeight,
       minHeight,
     }));


### PR DESCRIPTION
Fixes auto-focus within a form when field is invalid. 

Take a look at https://shadcnui-expansions.typeart.cc/docs/autosize-textarea#Form 
Remove all the prepopulated text in the text area, open the dev console, hit the submit button. 
You will get this error: `Uncaught (in promise) TypeError: e.focus is not a function`

This PR fixes this.