### PR TITLE
Updates multiple-selector to support focus

### DIFF
--- a/app/(docs)/docs/multiple-selector/usage/multiple-selector-with-form.tsx
+++ b/app/(docs)/docs/multiple-selector/usage/multiple-selector-with-form.tsx
@@ -74,8 +74,7 @@ const MultipleSelectorWithForm = () => {
               <FormLabel>Frameworks</FormLabel>
               <FormControl>
                 <MultipleSelector
-                  value={field.value}
-                  onChange={field.onChange}
+                  {...field}
                   defaultOptions={OPTIONS}
                   placeholder="Select frameworks you like..."
                   emptyIndicator={

--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -199,6 +199,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       () => ({
         selectedValue: [...selected],
         input: inputRef.current as HTMLInputElement,
+        focus: () => inputRef.current?.focus(),
       }),
       [selected],
     );
@@ -221,7 +222,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
               handleUnselect(selected[selected.length - 1]);
             }
           }
-          // This is not a default behaviour of the <input /> field
+          // This is not a default behavior of the <input /> field
           if (e.key === 'Escape') {
             input.blur();
           }


### PR DESCRIPTION
This is handy for auto-focus when then field is invalid when used in a form

Test: 
1. Go to https://shadcnui-expansions.typeart.cc/docs/multiple-selector#Form
2. Hit submit on an empty field
3. The form should be auto-focused