### PR TITLE
Updates multiple-selector.tsx styling

### DIFF
--- a/app/(docs)/docs/multiple-selector/usage/multiple-selector-with-form.tsx
+++ b/app/(docs)/docs/multiple-selector/usage/multiple-selector-with-form.tsx
@@ -74,8 +74,7 @@ const MultipleSelectorWithForm = () => {
               <FormLabel>Frameworks</FormLabel>
               <FormControl>
                 <MultipleSelector
-                  value={field.value}
-                  onChange={field.onChange}
+                  {...field}
                   defaultOptions={OPTIONS}
                   placeholder="Select frameworks you like..."
                   emptyIndicator={

--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -367,7 +367,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       >
         <div
           className={cn(
-            'h-full min-h-10 rounded-md border border-input text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+            'min-h-10 rounded-md border border-input text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
             {
               'px-3 py-2': selected.length !== 0,
               'cursor-text': !disabled && selected.length !== 0,

--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -367,9 +367,17 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       >
         <div
           className={cn(
-            'h-full min-h-10 rounded-md border border-input px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+            'h-full min-h-10 rounded-md border border-input text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+            {
+              'px-3 py-2': selected.length !== 0,
+              'cursor-text': !disabled && selected.length !== 0,
+            },
             className,
           )}
+          onClick={() => {
+            if (disabled) return;
+            inputRef.current?.focus();
+          }}
         >
           <div className="flex flex-wrap gap-1">
             {selected.map((option) => {
@@ -427,9 +435,11 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
               }}
               placeholder={hidePlaceholderWhenSelected && selected.length !== 0 ? '' : placeholder}
               className={cn(
-                'ml-2 flex-1 bg-transparent outline-none placeholder:text-muted-foreground',
+                'flex-1 bg-transparent outline-none placeholder:text-muted-foreground',
                 {
                   'w-full': hidePlaceholderWhenSelected,
+                  'px-3 py-2': selected.length === 0,
+                  'ml-1': selected.length !== 0,
                 },
                 inputProps?.className,
               )}

--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -199,6 +199,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       () => ({
         selectedValue: [...selected],
         input: inputRef.current as HTMLInputElement,
+        focus: () => inputRef.current?.focus(),
       }),
       [selected],
     );
@@ -221,7 +222,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
               handleUnselect(selected[selected.length - 1]);
             }
           }
-          // This is not a default behaviour of the <input /> field
+          // This is not a default behavior of the <input /> field
           if (e.key === 'Escape') {
             input.blur();
           }

--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -359,7 +359,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
           handleKeyDown(e);
           commandProps?.onKeyDown?.(e);
         }}
-        className={cn('overflow-visible bg-transparent', commandProps?.className)}
+        className={cn('h-auto overflow-visible bg-transparent', commandProps?.className)}
         shouldFilter={
           commandProps?.shouldFilter !== undefined ? commandProps.shouldFilter : !onSearch
         } // When onSearch is provided, we don't want to filter the options. You can still override it.
@@ -367,7 +367,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       >
         <div
           className={cn(
-            'group rounded-md border border-input px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+            'h-full min-h-10 rounded-md border border-input px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
             className,
           )}
         >
@@ -428,14 +428,17 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
               placeholder={hidePlaceholderWhenSelected && selected.length !== 0 ? '' : placeholder}
               className={cn(
                 'ml-2 flex-1 bg-transparent outline-none placeholder:text-muted-foreground',
+                {
+                  'w-full': hidePlaceholderWhenSelected,
+                },
                 inputProps?.className,
               )}
             />
           </div>
         </div>
-        <div className="relative mt-2">
+        <div className="relative">
           {open && (
-            <CommandList className="absolute top-0 z-10 w-full rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
+            <CommandList className="absolute top-1 z-10 w-full rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
               {isLoading ? (
                 <>{loadingIndicator}</>
               ) : (


### PR DESCRIPTION
Please see commit messages for details: 

They are: 
Commit 1: (f30df1be6259ced12cbe99a35ba9bf87a1877bab) 
- Sets heights ... particularly useful when in a grid, because the used Command component is set to `h-full` so it expands to fit the grid cell. Instead sets to `h-auto` so height depend on that of it's children
- sets height of div to `min-h-10` so it matches Shadcn `Select` and `Input` elements height size and `h-full` so it expand to fit selected elements (`h-full` is removed later in commit 3)
- sets CommandPrimitive.Input w-full when hidePlaceholderWhenSelected = true ... useful to prevent unnecessary new lines
- removes CommandList 's `mt-2` in favor or `top-1`. uses `top-1` instead of `top-2` to match spacing between Shadcn's SelectTrigger and SelectContent


Commit 2 (0af15b0e24b9a878cacde0855aa760049390c448): 
- Makes padding of wrapping div conditional on if items are selected and the CommandPrimitive.Input padding conditional on if NO items are selected. This is useful to 1) center the placeholder when no items are selected 2) make the whole component clickable when no elements are selected (instead of precisely clicking on the CommandPrimitive.Input 3) maintain the padding when items are selected 
- Add's `onClick()` coupled with `cursor-text` on wrapping div so a click anywhere on the field focuses on the CommandPrimitive.Input 
- Add `ml-1` on CommandPrimitive.Input only when items are selected, again maintain same padding as existing Shadcn components

Commit 3: (c2609fdd22ba5fa82df83f8521811907b9d0bf88)
- Removes unnecessary `h-full` on wrapping `div` element