### PR TITLE
Fix disabled styles applied on badged selected items when disabled:false

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -382,7 +382,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
                     badgeClassName,
                   )}
                   data-fixed={option.fixed}
-                  data-disabled={disabled}
+                  data-disabled={disabled || undefined}
                 >
                   {option.label}
                   <button


### PR DESCRIPTION
This pull request addresses an issue encountered with the badge component. Following selection, the badge item exhibits disabled styles, despite the `disabled:false` property being set. 

Investigation revealed that the presence of `data-disabled="false"` in the HTML attribute triggers unintended tailwind rules (`.data-\[disabled\]`). This behavior, which was not previously observed, arose unexpectedly after a period of time. 

This update aims to rectify the styling inconsistency by refining JSX configuration to prevent the unintended application of styles to elements when `disabled: false`

<img width="632" alt="Screenshot 2024-05-14 at 21 06 53" src="https://github.com/hsuanyi-chou/shadcn-ui-expansions/assets/45426001/3fcbad9c-a75b-454c-abfc-0436213911c8">

In my case, I used the MultipleSelector component with the `canEdit` property set to true, thus ensuring that `disabled` was false. You can confirm this by referring to the screenshot above, where you can see `data-disabled="false"` in the HTML attribute of the selected item.

<img width="792" alt="Screenshot 2024-05-14 at 21 12 19" src="https://github.com/hsuanyi-chou/shadcn-ui-expansions/assets/45426001/4ba614a5-8968-4215-9b98-88466e10a44c">
