### PR TITLE
Fix handling of backspace and delete key in MultipleSelector

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -219,7 +219,11 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
         if (input) {
           if (e.key === 'Delete' || e.key === 'Backspace') {
             if (input.value === '' && selected.length > 0) {
-              handleUnselect(selected[selected.length - 1]);
+              const lastSelectOption  = selected[selected.length - 1];
+              // If last item is fixed, we should not remove it.
+              if(!lastSelectOption.fixed) {
+                handleUnselect(selected[selected.length - 1]);
+              }
             }
           }
           // This is not a default behavior of the <input /> field


### PR DESCRIPTION
Fixes #86 

Adds basic check to ensure the option that the user is attempting to remove is not fixed. This aligns with the expected behavior of a fixed option. (i.e. an option that is there and can not be removed).