### PR TITLE
🐛 fix aria label warnings

### DIFF
--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -217,7 +217,7 @@ function DateField(props: AriaDatePickerProps<DateValue>) {
     locale,
     createCalendar,
   });
-  const { fieldProps } = useDateField(props, state, ref);
+  const { fieldProps } = useDateField({ ...props, 'aria-label': 'date-field' }, state, ref);
 
   return (
     <div
@@ -310,7 +310,7 @@ const DateTimePicker = React.forwardRef<
     buttonProps: _buttonProps,
     dialogProps,
     calendarProps,
-  } = useDatePicker(props, state, divRef);
+  } = useDatePicker({ ...props, 'aria-label': 'date-picker' }, state, divRef);
   const { buttonProps } = useButton(_buttonProps, buttonRef);
 
   const currentValue = useCallback(() => {

--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -247,7 +247,7 @@ function TimeField(props: AriaTimeFieldProps<TimeValue>) {
   const {
     fieldProps: { ...fieldProps },
     labelProps,
-  } = useTimeField(props, state, ref);
+  } = useTimeField({ ...props, 'aria-label': 'time-field' }, state, ref);
 
   return (
     <div


### PR DESCRIPTION
This PR fixed the 2 warnings regarding aria labels on the datetime-picker component.

Warning:
![Capture d’écran 2024-06-08 à 19 52 43](https://github.com/hsuanyi-chou/shadcn-ui-expansions/assets/56249726/cb28ef65-9681-40a4-bb98-78c50790182b)

The warnings are displayed in dev mode.
I tested it on Arc, Chrome, Firefox.