### PR TITLE
Improve semantics of datetime-picker

### DIFF
--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -187,10 +187,11 @@ function convert12HourTo24Hour(hour: number, period: Period) {
   if (period === 'PM') {
     if (hour <= 11) {
       return hour + 12;
-    } else {
-      return hour;
-    }
-  } else if (period === 'AM') {
+    } 
+    return hour;
+  } 
+  
+  if (period === 'AM') {
     if (hour === 12) return 0;
     return hour;
   }

--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -645,7 +645,7 @@ type DateTimePickerRef = {
   value?: Date;
 } & Omit<HTMLButtonElement, 'value'>;
 
-const DateTimePicker = React.forwardRef<DateTimePickerRef, DateTimePickerProps>(
+const DateTimePicker = React.forwardRef<Partial<DateTimePickerRef>, DateTimePickerProps>(
   (
     {
       locale = enUS,
@@ -684,7 +684,7 @@ const DateTimePicker = React.forwardRef<DateTimePickerRef, DateTimePickerProps>(
     useImperativeHandle(
       ref,
       () => ({
-        ...buttonRef.current!,
+        ...buttonRef.current,
         value,
       }),
       [value],

--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -455,10 +455,10 @@ const TimePickerInput = React.forwardRef<HTMLInputElement, TimePickerInputProps>
        * The second entered digit will break the condition and the value will be set to 10-12.
        */
       if (picker === '12hours') {
-        if (flag && calculatedValue.slice(1, 2) === '1' && prevIntKey === '0') return '0' + key;
+        if (flag && calculatedValue.slice(1, 2) === '1' && prevIntKey === '0') return `0${key}`;
       }
 
-      return !flag ? '0' + key : calculatedValue.slice(1, 2) + key;
+      return !flag ? `0${key}` : calculatedValue.slice(1, 2) + key;
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -46,7 +46,7 @@ type GetValidNumberConfig = { max: number; min?: number; loop?: boolean };
 function getValidNumber(value: string, { max, min = 0, loop = false }: GetValidNumberConfig) {
   let numericValue = parseInt(value, 10);
 
-  if (!isNaN(numericValue)) {
+  if (!Number.isNaN(numericValue)) {
     if (!loop) {
       if (numericValue > max) numericValue = max;
       if (numericValue < min) numericValue = min;
@@ -83,7 +83,7 @@ type GetValidArrowNumberConfig = {
 
 function getValidArrowNumber(value: string, { min, max, step }: GetValidArrowNumberConfig) {
   let numericValue = parseInt(value, 10);
-  if (!isNaN(numericValue)) {
+  if (!Number.isNaN(numericValue)) {
     numericValue += step;
     return getValidNumber(String(numericValue), { min, max, loop: true });
   }

--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -691,9 +691,13 @@ const DateTimePicker = React.forwardRef<Partial<DateTimePickerRef>, DateTimePick
     );
 
     const initHourFormat = {
-      hour24: displayFormat?.hour24 ?? 'PPP HH:mm:ss',
-      hour12: displayFormat?.hour12 ?? 'PP hh:mm:ss b',
-    };
+			hour24:
+				displayFormat?.hour24 ??
+				`PPP HH:mm${!granularity || granularity === "second" ? ":ss" : ""}`,
+			hour12:
+				displayFormat?.hour12 ??
+				`PP hh:mm${!granularity || granularity === "second" ? ":ss" : ""} b`,
+		};
 
     let loc = enUS;
     const { options, localize, formatLong } = locale;

--- a/components/ui/datetime-picker.tsx
+++ b/components/ui/datetime-picker.tsx
@@ -157,8 +157,7 @@ function getDateByType(date: Date | null, type: TimePickerType) {
     case 'hours':
       return getValidHour(String(date.getHours()));
     case '12hours':
-      const hours = display12HourValue(date.getHours());
-      return getValid12Hour(String(hours));
+      return getValid12Hour(String(display12HourValue(date.getHours())));
     default:
       return '00';
   }


### PR DESCRIPTION
For people with stricter lint rules, I'd suggest the following updates in `datetime-picker.ts`:

- `noGlobalIsNaN` -> https://biomejs.dev/linter/rules/no-global-is-nan/ | Affected lines: 49, 86
- `noSwitchDeclarations` → https://biomejs.dev/linter/rules/no-switch-declarations/ | Affected line: 160
- `noUselessElse` → https://biomejs.dev/linter/rules/no-useless-else/ | Affected lines: 190 and following
- `useTemplate` → https://biomejs.dev/linter/rules/use-template/ | Affected lines: 458, 461
- `noNonNullAssertion` → https://biomejs.dev/linter/rules/no-non-null-assertion/ | Affected lines: 648, 687