### PR TITLE
feat: add reset of selected items in multiple selector

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -82,6 +82,8 @@ interface MultipleSelectorProps {
 export interface MultipleSelectorRef {
   selectedValue: Option[];
   input: HTMLInputElement;
+  focus: () => void;
+  reset: () => void;
 }
 
 export function useDebounce<T>(value: T, delay?: number): T {
@@ -212,6 +214,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
         selectedValue: [...selected],
         input: inputRef.current as HTMLInputElement,
         focus: () => inputRef.current?.focus(),
+        reset: () => setSelected([])
       }),
       [selected],
     );
@@ -528,7 +531,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
                   disabled ||
                   selected.length < 1 ||
                   selected.filter((s) => s.fixed).length === selected.length) &&
-                  'hidden',
+                'hidden',
               )}
             >
               <X />


### PR DESCRIPTION
Include the functionality to reset the select items in the multiple selector. 

It can be used in a similar way like resetting a form. 

Example
```
export default function MultipleSelectorComponent() {
    const multipleSelectorRef = useRef<MultipleSelectorRef>(null);
    return (
        <form
            onSubmit={() => {
                multipleSelectorRef.current?.submit();
            }}
        >
           <MultipleSelector ref={multipleSelectorRef} />
        ...
        </form>
    )
}
```


