### PR TITLE
fix: filter searched options by label (not value) in multiple-selector

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -566,7 +566,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
                           return (
                             <CommandItem
                               key={option.value}
-                              value={option.value}
+                              value={option.label}
                               disabled={option.disable}
                               onMouseDown={(e) => {
                                 e.preventDefault();


### PR DESCRIPTION
I guess users expect the displayed options to be filtered by label, not the "invisible" value.