### PR TITLE
Added type button to unselect button in multiple selector badge

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -440,7 +440,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
       >
         <div
           className={cn(
-            'min-h-10 rounded-md border border-input text-base md:text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+            'min-h-10 rounded-md border border-input text-base ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 md:text-sm',
             {
               'px-3 py-2': selected.length !== 0,
               'cursor-text': !disabled && selected.length !== 0,
@@ -467,6 +467,7 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
                 >
                   {option.label}
                   <button
+                    type="button"
                     className={cn(
                       'ml-1 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2',
                       (disabled || option.fixed) && 'hidden',


### PR DESCRIPTION
This PR fixes an issue that occurs when the `MultipleSelector` component is used inside a `<form>`.

When an unselect `<button>` inside the component doesn't have an explicit `type="button"`, browsers treat it as a submit button by default. This causes unintended behavior: if a user selects an item in the `MultipleSelector`, moves to another input field and presses Enter, the unselect button may be triggered instead of submitting the form — unintentionally removing a selected item.

To prevent this, I added type="button" to the unselect button to isolate it from the form submission behavior and ensure the component works properly within form contexts.