### PR TITLE
fix: use lastSelectOption to prevent Option cannot be undefined error

### DIFF
--- a/components/ui/multiple-selector.tsx
+++ b/components/ui/multiple-selector.tsx
@@ -247,9 +247,9 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
           if (e.key === 'Delete' || e.key === 'Backspace') {
             if (input.value === '' && selected.length > 0) {
               const lastSelectOption = selected[selected.length - 1];
-              // If last item is fixed, we should not remove it.
-              if (!lastSelectOption.fixed) {
-                handleUnselect(selected[selected.length - 1]);
+              // If there is a last item and it is not fixed, we can remove it.
+              if (lastSelectOption && !lastSelectOption.fixed) {
+                handleUnselect(lastSelectOption);
               }
             }
           }


### PR DESCRIPTION
This pull request fixes a potential error in the MultipleSelector component.
Previously, TypeScript would warn that "Option cannot be undefined" when handling Delete or Backspace key events.
The logic now checks whether lastSelectOption is defined before attempting to unselect it.
Also it actually uses the variable i guess.