### PR TITLE
fix: navigation visibility between 768–1024px breakpoints (docs)

### DIFF
--- a/app/(docs)/layout-parts/navbar/hamburger.tsx
+++ b/app/(docs)/layout-parts/navbar/hamburger.tsx
@@ -1,16 +1,16 @@
 'use client';
-import React, { useState } from 'react';
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
-import { Menu } from 'lucide-react';
 import { DOCS } from '@/app/(docs)/layout-parts/documentation.constant';
 import LeftSideLink from '@/app/(docs)/layout-parts/left-side/left-side-link';
 import { LogoLink } from '@/app/(docs)/layout-parts/navbar/navbar-logo';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { Menu } from 'lucide-react';
+import { useState } from 'react';
 
 const Hamburger = () => {
   const [open, setOpen] = useState(false);
   return (
     <Sheet open={open} onOpenChange={(o) => setOpen(o)}>
-      <SheetTrigger className="cursor-pointer md:hidden">
+      <SheetTrigger className="cursor-pointer lg:hidden">
         <Menu />
       </SheetTrigger>
       <SheetContent side="left">

--- a/app/(docs)/layout-parts/navbar/navbar-logo.tsx
+++ b/app/(docs)/layout-parts/navbar/navbar-logo.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import Link from 'next/link';
 import Logo from '@/app/(docs)/layout-parts/logo/logo';
 import Hamburger from '@/app/(docs)/layout-parts/navbar/hamburger';
 import { cn } from '@/lib/utils';
+import Link from 'next/link';
 
 interface LogoLinkProps {
   alwaysRender?: boolean;
@@ -11,7 +10,7 @@ interface LogoLinkProps {
 
 export const LogoLink = ({ alwaysRender, className }: LogoLinkProps) => {
   return (
-    <Link className={cn('hidden gap-1 md:flex', alwaysRender && 'flex', className)} href="/">
+    <Link className={cn('hidden gap-1 lg:flex', alwaysRender && 'flex', className)} href="/">
       <Logo />
       <span className="text-xl font-bold">shadcn/ui expansions</span>
     </Link>


### PR DESCRIPTION
Fixed issue where navigation was hidden between md–lg (768px–1024px) breakpoints. Now, the hamburger menu is shown up to 1024px and above that the, LeftSide component appears as expected. This fixes the case where navigation was entirely missing on medium-large screens.